### PR TITLE
consider situations where mockingdate is not set

### DIFF
--- a/src/withMockTime.ts
+++ b/src/withMockTime.ts
@@ -5,6 +5,7 @@ import type {
 } from "@storybook/types";
 import FakeTimers from "@sinonjs/fake-timers";
 
+const now = new Date();
 let clock: FakeTimers.Clock | undefined;
 
 export const withMockTime = (
@@ -12,6 +13,13 @@ export const withMockTime = (
   context: StoryContext<Renderer>
 ) => {
   const mockingDate = context.parameters.mockingDate;
+
+  if (!mockingDate) {
+    if (clock) {
+      clock.setSystemTime(now);
+    }
+    return StoryFn(context);
+  }
 
   if (!clock) {
     clock = FakeTimers.install({


### PR DESCRIPTION
close #6 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.4--canary.7.42bee75.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-mock-date@0.4.4--canary.7.42bee75.0
  # or 
  yarn add storybook-addon-mock-date@0.4.4--canary.7.42bee75.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
