### PR TITLE
feat: migrate to npm OIDC authentication

### DIFF
--- a/.changeset/npm-oidc-migration.md
+++ b/.changeset/npm-oidc-migration.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-mock-date": patch
+---
+
+Migrate to npm OIDC authentication for secure publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,6 +34,4 @@ jobs:
         with:
           publish: npm run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           node-version-file: package.json
 
+      # OIDC support is available from npm 11.5.1+
+      - name: Install latest npm
+        run: npm install -g npm@11.5.1
+
       - name: Install dependencies
         run: npm install --ignore-scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Create release Pull Request or publish to NPM
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
           publish: npm run release
         env:


### PR DESCRIPTION
## Summary
• Remove NPM_TOKEN secrets and migrate to OIDC authentication
• Pin npm version to 11.5.1+ for OIDC support
• Update GitHub Actions to secure versions
• Add changeset for patch version bump

## Changes
- Added OIDC permissions (contents: write, id-token: write, pull-requests: write)
- Removed NODE_AUTH_TOKEN and NPM_TOKEN environment variables
- Pinned npm to version 11.5.1 with OIDC support comment
- Updated checkout action to v5
- Pinned changesets action to specific commit hash
- Added changeset for npm OIDC migration

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Confirm OIDC authentication works for npm publishing
- [ ] Check that version bump is applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)