### PR TITLE
chore: relax Node.js version requirement to >=22.0.0

### DIFF
--- a/.changeset/relax-node-version.md
+++ b/.changeset/relax-node-version.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-mock-date": patch
+---
+
+Relax Node.js version requirement from 24.4.1 to >=22.0.0 for better compatibility

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "*.d.ts"
   ],
   "engines": {
-    "node": "24.4.1"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@10.24.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- Changed Node.js engine requirement from a specific version (24.4.1) to a minimum version (>=22.0.0)
- This provides more flexibility for users while maintaining compatibility with supported Node.js versions

## Motivation
The previous requirement locked the project to a specific Node.js version (24.4.1), which was overly restrictive. By using a minimum version requirement instead, users can work with any Node.js version 22.0.0 or higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)