### PR TITLE
docs: expand README with description, requirements, and mocking scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Storybook Addon Mocking Date
 
+A [Storybook](https://storybook.js.org/) addon that mocks the JavaScript `Date` for individual stories using [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers). Useful for components that read the current date or time and need deterministic snapshots, visual regression tests, or coverage of time-sensitive UI such as relative timestamps and seasonal greetings.
+
+## Requirements
+
+- Storybook `^10.0.0`
+- Renderer-agnostic — the addon ships a preview decorator that works with any Storybook framework (React, Vue, Svelte, etc.)
+
 ## Installation
 
 First, install the package.
@@ -8,12 +15,12 @@ First, install the package.
 npm install --save-dev storybook-addon-mock-date
 ```
 
-Then, register it as an addon in `.storybook/main.js`.
+Then, register it as an addon in `.storybook/main.ts`.
 
-```js
+```ts
 // .storybook/main.ts
 
-// Replace your-framework with the framework you are using (e.g., react-webpack5, vue3-vite)
+// Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite)
 import type { StorybookConfig } from '@storybook/your-framework';
 
 const config: StorybookConfig = {
@@ -28,9 +35,9 @@ export default config;
 
 ## Usage
 
-Mock the current time in `Date` by passing `Date | number` in `mockingDate` of `parameters`.
+Pass a `Date` (or a millisecond timestamp) via the `mockingDate` parameter at the story, meta, or preview level. Storybook merges parameters with the most specific value winning, so the precedence is **story > meta > preview**.
 
-```js
+```ts
 // Button.stories.ts
 
 // Replace your-framework with the name of your framework
@@ -49,7 +56,6 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-
 export const AddParametersAtStory: Story = {
   parameters: {
     mockingDate: new Date(2023, 6, 1),
@@ -59,11 +65,11 @@ export const AddParametersAtStory: Story = {
 export const AddParametersAtMeta: Story = {};
 ```
 
-```js
+```ts
 // .storybook/preview.ts
 
-// Replace your-renderer with the name of you renderer
-import type { Preview } from "@storybook/your-renderer";
+// Replace your-renderer with the name of your renderer
+import type { Preview } from '@storybook/your-renderer';
 
 const preview: Preview = {
   parameters: {
@@ -73,3 +79,9 @@ const preview: Preview = {
 
 export default preview;
 ```
+
+A story whose merged `mockingDate` is `undefined` reverts the system clock to the moment the preview iframe loaded, so subsequent stories continue to see a deterministic value rather than continuing to drift forward.
+
+### What gets mocked
+
+Only the `Date` constructor and its static methods (`Date.now`, `Date.parse`, etc.) are replaced. `setTimeout`, `setInterval`, `requestAnimationFrame`, and the rest of the timer APIs continue to use the host clock unchanged.


### PR DESCRIPTION
## Summary

Adds the bits the README was missing, mostly so users can answer "is this addon for me?" without scrolling.

- Lead with a one-line description of what the addon does and which library powers the date mocking (`@sinonjs/fake-timers`).
- Add a **Requirements** section that pins the supported storybook range (`^10.0.0`) and notes the addon is renderer-agnostic — the only contract is the `mockingDate` parameter, so it works with any framework.
- Document the **parameter precedence** (`story > meta > preview`) and the **reset behaviour** when `mockingDate` is `undefined`. Both are non-obvious from the snippets alone.
- Add a **What gets mocked** section that calls out the scope: only `Date` (constructor + static methods) is replaced. `setTimeout`, `setInterval`, `requestAnimationFrame`, etc. continue to use the host clock. Several issues in similar addons trace back to assuming timers are also mocked.
- Update the example placeholder framework from the obsolete `react-webpack5` to `react-vite`.

No code changes, no behaviour change.

## Test plan

- [x] `pnpm vp check` (fmt + lint) passes — README is included in the formatter scope.
