### PR TITLE
ci: configure git user as k8o bot and drop npm@latest install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,22 +24,36 @@ jobs:
           client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
           private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
 
+      - name: Resolve GitHub App user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+        run: |
+          user_id=$(gh api "users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=${user_id}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Configure git user as GitHub App
+        env:
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
+        run: |
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
       - name: Install
         uses: ./.github/composite-actions/install
-
-      # OIDC support is available from npm 11.5.1+
-      - name: Install latest npm
-        run: npm install -g npm@latest
 
       - name: Create release Pull Request or publish to NPM
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm run release
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Resolve the k8o-bot App's numeric user id and set it as the git commit author before running `changesets/action`
- Pass `setupGitUser: false` so the action doesn't overwrite the configured user with the default `github-actions[bot]`
- Mirrors the release workflow used in [k35o/arte-odyssey](https://github.com/k35o/arte-odyssey/blob/main/.github/workflows/release.yml)
- Drops `npm install -g npm@latest` — the runner's npm is now new enough for OIDC trusted publishing

Now the Version Packages PR and release commits are authored by `k8o-bot[bot]` instead of `github-actions[bot]`.

## Test plan

- [ ] Workflow run succeeds on merge to main
- [ ] Version Packages PR (when there is a pending changeset) is opened by k8o-bot
- [ ] OIDC trusted publishing still works on actual release