### PR TITLE
fix: uninstall fake clock on story switch with no mockingDate

### DIFF
--- a/.changeset/fix-uninstall-clock-on-story-switch.md
+++ b/.changeset/fix-uninstall-clock-on-story-switch.md
@@ -1,0 +1,15 @@
+---
+'storybook-addon-mock-date': patch
+---
+
+Fix the mocked clock leaking into stories that have no `mockingDate`.
+
+When switching from a story with `mockingDate` to a story where the
+parameter is undefined (no story / meta / preview / global value), the
+decorator used to call `clock.setSystemTime(now)` with a `now` captured
+at module load. The fake `Date` stayed installed and froze at that
+captured value, so subsequent `new Date()` calls returned a stale time
+instead of the real one.
+
+The decorator now calls `clock.uninstall()` and clears the cached
+reference in that path, restoring the native `Date`.

--- a/src/with-mock-time.ts
+++ b/src/with-mock-time.ts
@@ -3,7 +3,6 @@ import type { PartialStoryFn, StoryContext } from 'storybook/internal/types';
 
 import { GLOBAL_KEY, PARAM_KEY } from './constants';
 
-const now = new Date();
 let clock: FakeTimers.Clock | undefined;
 
 const toDate = (
@@ -38,7 +37,8 @@ export const withMockTime = (
 
   if (mockingDate === undefined) {
     if (clock) {
-      clock.setSystemTime(now);
+      clock.uninstall();
+      clock = undefined;
     }
     // eslint-disable-next-line typescript/no-unsafe-return -- Storybook's PartialStoryFn return type is loosely typed
     return StoryFn(context);


### PR DESCRIPTION
## Summary

- Fix a bug where the fake clock leaked across stories: switching from a story with `mockingDate` set to one without it left the fake `Date` installed, so subsequent stories saw a frozen time captured at module load.
- The decorator now calls `clock.uninstall()` (instead of `clock.setSystemTime(now)`) when no `mockingDate` is resolved, restoring the native `Date`.

## Background

A user reported that, in projects that do not set a global `mockingDate` in `.storybook/preview.ts`, switching from a mocked story back to an "unmocked" story did not release the mock. Comparing `src/with-mock-time.ts` against v0.6.0 confirmed both versions take the same `clock.setSystemTime(now)` path on that branch, where `now` is captured once at module load. Because `uninstall()` is never called, the fake `Date` stays installed and every `new Date()` returns the stale `now` value.

## Test plan

- [x] All existing tests pass: 6/6 (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] `pnpm check` clean
- [x] Manual repro in the dev Storybook with `preview.ts`'s global `mockingDate` removed: navigated from a mocked story to a story with no `mockingDate` via the sidebar (no iframe reload) and confirmed `Date.name === "Date"` and that `new Date()` advances 3s after a 3s `setTimeout`.