### PR TITLE
chore: lower engines.node to >=22.0.0 for maintenance LTS users

### DIFF
--- a/.changeset/lower-node-engines-to-22.md
+++ b/.changeset/lower-node-engines-to-22.md
@@ -1,0 +1,13 @@
+---
+'storybook-addon-mock-date': patch
+---
+
+Lower the `engines.node` requirement back to `>=22.0.0` so consumers
+running on the current Node.js maintenance LTS (22.x, supported until
+April 2027) can install the addon without warnings.
+
+This addon's published code is browser-only (Storybook preview and
+manager bundles) and uses no Node.js APIs at runtime. Storybook 10
+itself only requires Node 20+, so 22 is comfortably within range.
+The repository's own development environment is still pinned to Node
+24 via `mise.toml` and CI, which is independent of this constraint.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "storybook": "$storybook"
   },
   "engines": {
-    "node": ">=24.13.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@11.1.1",
   "storybook": {


### PR DESCRIPTION
## Summary

- Relax `package.json` `engines.node` from `>=24.13.0` back to `>=22.0.0` so consumers on the current Node.js maintenance LTS (22.x, supported until April 2027) can install this addon without `engines` warnings.
- This addon publishes browser-only code (Storybook preview / manager bundles) and uses no Node.js APIs at runtime. Storybook 10 itself only requires Node 20+ per the official install docs, so 22 is comfortably within the supported range.
- Development tooling and CI are unaffected: `mise.toml` still pins Node 24 for contributors and the CI workflows install Node 24 via the shared composite action.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm check` clean
- [x] `pnpm test` 6/6 PASS
- [x] Changeset added (patch)