### PR TITLE
Add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "type": "git",
     "url": "https://github.com/k35o/storybook-addon-mock-date.git"
   },
+  "homepage": "https://github.com/k35o/storybook-addon-mock-date#readme",
+  "bugs": {
+    "url": "https://github.com/k35o/storybook-addon-mock-date/issues"
+  },
   "files": [
     "dist/**/*",
     "README.md"


### PR DESCRIPTION
## Summary

Adds the standard npm `homepage` and `bugs.url` metadata fields to `package.json`.

The published `storybook-addon-mock-date@3.0.2` package already exposes `repository`, but `npm view` does not expose `homepage` or `bugs`.

## Verification

```sh
npm view storybook-addon-mock-date@3.0.2 name version homepage repository bugs deprecated dist.tarball scripts --json
node metadata smoke check
npm pack --dry-run --ignore-scripts
npx --yes pnpm@11.4.0 install --frozen-lockfile --ignore-scripts
npx --yes pnpm@11.4.0 run build
npx --yes pnpm@11.4.0 run typecheck
npx --yes pnpm@11.4.0 run test
npx --yes pnpm@11.4.0 run check
npm pack --dry-run --ignore-scripts
git diff --check
```

Results:

- Published package metadata currently lacks `homepage` and `bugs`.
- Metadata smoke passed with the expected homepage, repository, and bugs URLs.
- pnpm frozen install passed.
- Build passed.
- Typecheck passed.
- Vitest passed: 2 files, 6 tests.
- `vp check` passed.
- `npm pack --dry-run --ignore-scripts` passed before and after build.
- Diff check passed.

The change is limited to package metadata; runtime code is unchanged.
