### PR TITLE
fix: add root preview/manager shims so absolute-path registration resolves

### DIFF
--- a/.changeset/root-shim-addon-resolution.md
+++ b/.changeset/root-shim-addon-resolution.md
@@ -1,0 +1,20 @@
+---
+'storybook-addon-mock-date': patch
+---
+
+Ship root-level `preview.js` / `manager.js` shims so the addon resolves when
+registered by absolute path.
+
+Storybook resolves an addon entry such as
+`getAbsolutePath('storybook-addon-mock-date')` as a filesystem path
+(`<dir>/preview`, `<dir>/manager`), which bypasses the `package.json`
+`exports` map. Because the package only exposed `./preview` and `./manager`
+through `exports` and shipped no physical files at the package root, that
+resolution failed and Storybook skipped the addon with
+`Could not resolve addon ... skipping. Is it installed?`. The mocked `Date`
+decorator was then never applied (notably under `@storybook/addon-vitest`).
+
+Following the convention of the official addons (`@storybook/addon-a11y`
+etc.), the package now ships root `preview.js` / `manager.js` re-export shims
+pointing at `./dist`, so both the absolute-path form and the bare specifier
+(`'storybook-addon-mock-date'`) resolve correctly.

--- a/manager.js
+++ b/manager.js
@@ -1,0 +1,1 @@
+export * from './dist/manager.js';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "files": [
     "dist/**/*",
+    "manager.js",
+    "preview.js",
     "README.md"
   ],
   "type": "module",

--- a/preview.js
+++ b/preview.js
@@ -1,0 +1,2 @@
+export * from './dist/preview.js';
+export { default } from './dist/preview.js';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
       'dist/**',
       'storybook-static/**',
       '.changeset/**',
+      'manager.js',
+      'preview.js',
     ],
   },
   lint: {
@@ -27,6 +29,8 @@ export default defineConfig({
       'dist/**',
       'storybook-static/**',
       '.changeset/**',
+      'manager.js',
+      'preview.js',
     ],
     options: {
       reportUnusedDisableDirectives: 'error',


### PR DESCRIPTION
## Problem

Storybook resolves an addon entry such as `getAbsolutePath('storybook-addon-mock-date')` (the package's absolute directory) as a filesystem path — it looks for `<dir>/preview` and `<dir>/manager` and does **not** go through the `package.json` `exports` map. Because this package only exposes `./preview` and `./manager` via `exports` and ships no physical files at the package root, that resolution fails and Storybook skips the addon with:

```
Could not resolve addon "…/storybook-addon-mock-date", skipping. Is it installed?
```

As a result the mocked `Date` decorator is never applied (notably under `@storybook/addon-vitest`).

## Fix

Following the convention of the official addons (`@storybook/addon-a11y`, etc.), ship root-level `preview.js` / `manager.js` re-export shims that point at `./dist`. Both the absolute-path form and the bare specifier (`'storybook-addon-mock-date'`) then resolve correctly.

- `preview.js` / `manager.js`: root shims re-exporting from `./dist`
- `package.json`: add the shims to the `files` allowlist so they are published
- `vite.config.ts`: exclude the dist-referencing shims from lint/format
- add a changeset (patch)

## Verification

- `pnpm build` ships the root shims and regenerates `dist`
- importing the root `preview.js` by absolute path resolves the default export carrying the `withMockTime` decorator
- `npm pack --dry-run` includes `manager.js` / `preview.js` in the tarball
- `pnpm check` (format/lint) and `pnpm test` (6 passed) are green