### PR TITLE
chore: add package support metadata

### DIFF
--- a/.changeset/calm-dates-read.md
+++ b/.changeset/calm-dates-read.md
@@ -1,0 +1,5 @@
+---
+"storybook-addon-mock-date": patch
+---
+
+Add package homepage and issue tracker metadata.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "type": "git",
     "url": "https://github.com/k35o/storybook-addon-mock-date.git"
   },
+  "homepage": "https://github.com/k35o/storybook-addon-mock-date#readme",
+  "bugs": {
+    "url": "https://github.com/k35o/storybook-addon-mock-date/issues"
+  },
   "files": [
     "dist/**/*",
     "manager.js",


### PR DESCRIPTION
## Summary

Adds npm support metadata to the package manifest:

- `homepage` pointing to the repository README
- `bugs.url` pointing to the GitHub issue tracker
- a patch changeset so the metadata can ship in the next package release

This keeps runtime code, dependencies, exports, and published file globs unchanged.

## Why

The current published metadata for `storybook-addon-mock-date@3.0.3` includes repository and license information, but does not expose homepage or bugs metadata. Adding these fields helps npm users and metadata consumers find the project README and issue tracker directly.

## Validation

- `node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); if(pkg.name !== 'storybook-addon-mock-date') throw new Error('wrong package'); if(pkg.homepage !== 'https://github.com/k35o/storybook-addon-mock-date#readme') throw new Error('homepage mismatch'); if(!pkg.bugs || pkg.bugs.url !== 'https://github.com/k35o/storybook-addon-mock-date/issues') throw new Error('bugs.url mismatch'); console.log(pkg.name, pkg.version, pkg.homepage, pkg.bugs.url)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm check`