### PR TITLE
feat: fake timers beyond Date and advance the clock in play

### DIFF
--- a/.changeset/expand-fake-set-and-advance.md
+++ b/.changeset/expand-fake-set-and-advance.md
@@ -1,0 +1,26 @@
+---
+"storybook-addon-mock-date": minor
+---
+
+Add opt-in faking of timers beyond `Date`, plus `play`-time clock controls.
+
+The `mockingDate` parameter now accepts an object form alongside the existing scalar:
+
+```ts
+parameters: {
+  mockingDate: {
+    now: '2024-01-01T00:00:00',
+    fake: ['Date', 'setTimeout', 'requestAnimationFrame', 'performance'],
+  },
+}
+```
+
+`fake` maps directly to [`@sinonjs/fake-timers`' `toFake`](https://github.com/sinonjs/fake-timers#var-clock--faketimersinstallconfig), so timer-driven UI — auto-dismissing toasts, debounced inputs, countdowns, count-ups, JS-driven animations — can be frozen for deterministic snapshots and visual regression tests, not just components that read `Date`. When `fake` is omitted it defaults to `['Date']`.
+
+To reach a settled "after" state (a dismissed toast, a finished count-up, an elapsed countdown), three helpers are now exported from `storybook-addon-mock-date/preview` for use inside a story's `play` — advancing has to happen after mount, once the component has registered its timers:
+
+- `advanceMockedTime(ms)` — advance the clock, running any timers scheduled within the window
+- `runAllMockedTimers()` — drain every scheduled timer
+- `getMockedClock()` — the raw clock, as an escape hatch
+
+Fully backwards compatible: the scalar `mockingDate` (a `Date`, a millisecond timestamp, or an ISO string) and the toolbar override behave exactly as before and still fake only `Date`.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,48 @@ export default preview;
 
 A story whose merged `mockingDate` is `undefined` reverts the system clock to the moment the preview iframe loaded, so subsequent stories continue to see a deterministic value rather than continuing to drift forward.
 
+### Faking other timers
+
+By default only `Date` is mocked. To freeze other JavaScript time sources too, pass the **object form** of `mockingDate` with a `fake` array — its values map directly to [`@sinonjs/fake-timers`' `toFake`](https://github.com/sinonjs/fake-timers#var-clock--faketimersinstallconfig) (e.g. `'setTimeout'`, `'setInterval'`, `'requestAnimationFrame'`, `'performance'`):
+
+```ts
+export const Toast: Story = {
+  parameters: {
+    mockingDate: {
+      now: '2024-01-01T00:00:00',
+      // intercept the auto-dismiss timer so the toast never races the screenshot
+      fake: ['Date', 'setTimeout', 'clearTimeout'],
+    },
+  },
+};
+```
+
+The scalar form (`mockingDate: new Date(...)`, a timestamp, or an ISO string) is unchanged and still fakes only `Date`, so existing stories keep working as-is. When `fake` is omitted it defaults to `['Date']`.
+
+> **rAF needs `performance`.** Animation libraries (framer-motion, react-spring, GSAP, Lottie, three.js) compute their delta from `performance.now()`, so fake `requestAnimationFrame` **and** `performance` together — faking rAF alone leaves the solver with a zero/NaN delta.
+
+### Advancing time in `play`
+
+Faking a timer _freezes_ it. To reach a settled "after" state (a dismissed toast, a finished count-up, an elapsed countdown), advance the clock from a story's `play` function with `advanceMockedTime` — **after** the component has mounted and registered its timers:
+
+```ts
+import { advanceMockedTime } from 'storybook-addon-mock-date/preview';
+
+export const AfterDismiss: Story = {
+  parameters: { mockingDate: { fake: ['setTimeout'] } },
+  play: async ({ canvas }) => {
+    advanceMockedTime(4000); // run the auto-dismiss timeout
+    // assert the dismissed state…
+  },
+};
+```
+
+`runAllMockedTimers()` (drain every scheduled timer) and `getMockedClock()` (the raw `@sinonjs/fake-timers` clock) are also exported from `storybook-addon-mock-date/preview` for finer control.
+
+> Always import these helpers from `storybook-addon-mock-date/preview` — the same entry the decorator ships from. They share a single module-level clock, so importing from any other path gives you a disconnected instance and a "called without an installed clock" error.
+
+> Advancing has to happen in `play`, not in a decorator: a component registers its timers in an effect that runs _after_ mount, so a decorator-level tick would fire before any timer exists.
+
 ### Toolbar override
 
 The addon registers a clock icon in the Storybook toolbar. Clicking it opens a popover with a `datetime-local` input and a **Reset to real time** button.
@@ -127,7 +169,9 @@ The decorator runs the same way; only the toolbar manager bundle is skipped.
 
 ### What gets mocked
 
-Only the `Date` constructor and its static methods (`Date.now`, `Date.parse`, etc.) are replaced. `setTimeout`, `setInterval`, `requestAnimationFrame`, and the rest of the timer APIs continue to use the host clock unchanged.
+By default only the `Date` constructor and its static methods (`Date.now`, `Date.parse`, etc.) are replaced; `setTimeout`, `setInterval`, `requestAnimationFrame`, and the rest of the timer APIs keep using the host clock. Opt into faking any of them per story with the `fake` option (see [Faking other timers](#faking-other-timers)).
+
+Note that `@sinonjs/fake-timers` only controls JavaScript timers and the clock. CSS animations/transitions, the Web Animations API, `IntersectionObserver`/`ResizeObserver`, and network requests are unaffected — disable or mock those separately for stable visual snapshots.
 
 ### Multiple stories in a docs page
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -11,3 +11,15 @@ const preview: ProjectAnnotations<Renderer> = {
 };
 
 export default preview;
+
+export {
+  advanceMockedTime,
+  getMockedClock,
+  runAllMockedTimers,
+} from './with-mock-time';
+export type {
+  FakeableTimer,
+  MockingDateConfig,
+  MockingDateParam,
+  MockingDateValue,
+} from './types';

--- a/src/stories/auto-dismiss-toast.stories.tsx
+++ b/src/stories/auto-dismiss-toast.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { advanceMockedTime } from 'storybook-addon-mock-date/preview';
+import { expect } from 'storybook/test';
+
+import { AutoDismissToast } from './auto-dismiss-toast';
+
+const meta = {
+  component: AutoDismissToast,
+  args: { message: '保存しました', duration: 4000 },
+  parameters: {
+    // Freeze Date and intercept setTimeout so the auto-dismiss never fires on
+    // its own — assertions and screenshots no longer race the 4s timer.
+    mockingDate: {
+      now: '2024-01-01T00:00:00',
+      fake: ['Date', 'setTimeout', 'clearTimeout'],
+    },
+  },
+} satisfies Meta<typeof AutoDismissToast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// setTimeout is faked, so yield through a real rAF to let React commit the
+// state update produced by advancing the clock.
+const flush = (): Promise<void> =>
+  new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      resolve();
+    });
+  });
+
+// Frozen at t=0: the toast stays visible because its timer never auto-fires.
+export const Shown: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('status')).toHaveTextContent('保存しました');
+  },
+};
+
+// Advance past the duration inside play to capture the dismissed state.
+export const AfterDismiss: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('status')).toBeInTheDocument();
+    advanceMockedTime(4000);
+    await flush();
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+};

--- a/src/stories/auto-dismiss-toast.tsx
+++ b/src/stories/auto-dismiss-toast.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+
+/**
+ * A minimal auto-dismissing toast. It mounts visible and hides itself after
+ * `duration` ms via `setTimeout` — exactly the kind of timer-driven UI that
+ * races the screenshot in VRT unless `setTimeout` is faked.
+ */
+export const AutoDismissToast: FC<{ message: string; duration?: number }> = ({
+  message,
+  duration = 4000,
+}) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setVisible(false);
+    }, duration);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [duration]);
+
+  if (!visible) {
+    return null;
+  }
+  return <output>{message}</output>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,29 @@
+import type { FakeMethod } from '@sinonjs/fake-timers';
+
+/** A point in time accepted by the `mockingDate` parameter. */
+export type MockingDateValue = Date | number | string;
+
+/**
+ * Timer / clock APIs that can be faked. Forwarded verbatim to
+ * `@sinonjs/fake-timers`' `toFake` option (e.g. `'Date'`, `'setTimeout'`,
+ * `'setInterval'`, `'requestAnimationFrame'`, `'performance'`).
+ */
+export type FakeableTimer = FakeMethod;
+
+/** Object form of the `mockingDate` parameter. */
+export type MockingDateConfig = {
+  /** The instant to freeze the clock at. Defaults to the epoch (`0`). */
+  now?: MockingDateValue;
+  /**
+   * Which timer / clock APIs to fake. Defaults to `['Date']`, matching the
+   * historical behaviour. Expand it to also intercept `setTimeout`,
+   * `setInterval`, `requestAnimationFrame`, `performance`, etc.
+   */
+  fake?: FakeableTimer[];
+};
+
+/**
+ * The `mockingDate` parameter accepts either a bare date value (legacy form,
+ * fakes only `Date`) or a configuration object.
+ */
+export type MockingDateParam = MockingDateValue | MockingDateConfig;

--- a/src/with-mock-time.ts
+++ b/src/with-mock-time.ts
@@ -2,57 +2,153 @@ import FakeTimers from '@sinonjs/fake-timers';
 import type { PartialStoryFn, StoryContext } from 'storybook/internal/types';
 
 import { GLOBAL_KEY, PARAM_KEY } from './constants';
+import type {
+  FakeableTimer,
+  MockingDateConfig,
+  MockingDateParam,
+  MockingDateValue,
+} from './types';
 
 let clock: FakeTimers.Clock | undefined;
+let installedFake: string | undefined;
 
-const toDate = (
-  value: Date | number | string | undefined,
-): Date | number | undefined => {
-  if (value === undefined || value === '') {
+const DEFAULT_FAKE: FakeableTimer[] = ['Date'];
+
+// Accepts `unknown` because Storybook parameters/globals are untyped at
+// runtime — this gracefully ignores `null` and any non-date junk instead of
+// crashing or installing a bogus clock.
+const toDate = (value: unknown): Date | number | undefined => {
+  if (value === undefined || value === null || value === '') {
     return undefined;
   }
   if (typeof value === 'string') {
     const parsed = new Date(value);
     return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   }
-  return value;
+  if (typeof value === 'number' || value instanceof Date) {
+    return value;
+  }
+  return undefined;
 };
+
+const isConfig = (value: unknown): value is MockingDateConfig =>
+  typeof value === 'object' && value !== null && !(value instanceof Date);
+
+type NormalizedMockingDate = {
+  now: Date | number | undefined;
+  fake: FakeableTimer[];
+};
+
+/**
+ * Resolve the `mockingDate` parameter (scalar or object form) together with
+ * the toolbar global into a normalized `{ now, fake }`. The toolbar only ever
+ * carries a date, so it overrides `now` while leaving `fake` untouched — that
+ * keeps a story's `fake` set alive even when a date is picked interactively.
+ */
+export const normalizeMockingDate = (
+  param: MockingDateParam | undefined,
+  globalValue: MockingDateValue | undefined,
+): NormalizedMockingDate => {
+  const config: MockingDateConfig = isConfig(param) ? param : { now: param };
+  const now = toDate(globalValue) ?? toDate(config.now);
+  const fake =
+    config.fake !== undefined && config.fake.length > 0
+      ? config.fake
+      : DEFAULT_FAKE;
+  return { now, fake };
+};
+
+const isDefaultFake = (fake: FakeableTimer[]): boolean =>
+  fake.length === 1 && fake[0] === 'Date';
+
+const fakeKeyOf = (fake: FakeableTimer[]): string => fake.toSorted().join(',');
 
 export const withMockTime = (
   StoryFn: PartialStoryFn,
   context: StoryContext,
 ) => {
-  const fromGlobal = context.globals[GLOBAL_KEY] as
-    | Date
-    | number
-    | string
-    | undefined;
-  const fromParameter = context.parameters[PARAM_KEY] as
-    | Date
-    | number
-    | string
-    | undefined;
+  const { now, fake } = normalizeMockingDate(
+    context.parameters[PARAM_KEY] as MockingDateParam | undefined,
+    context.globals[GLOBAL_KEY] as MockingDateValue | undefined,
+  );
 
-  const mockingDate = toDate(fromGlobal) ?? toDate(fromParameter);
+  // Preserve the original behaviour: with no date and only the default
+  // `['Date']` fake set there is nothing to mock.
+  const shouldMock = now !== undefined || !isDefaultFake(fake);
 
-  if (mockingDate === undefined) {
+  if (!shouldMock) {
     if (clock) {
       clock.uninstall();
       clock = undefined;
+      installedFake = undefined;
     }
     // eslint-disable-next-line typescript/no-unsafe-return -- Storybook's PartialStoryFn return type is loosely typed
     return StoryFn(context);
   }
 
+  const nextKey = fakeKeyOf(fake);
+  // `toFake` cannot be changed on an already-installed clock, so reinstall
+  // whenever the requested set differs from what is currently installed.
+  if (clock && installedFake !== nextKey) {
+    clock.uninstall();
+    clock = undefined;
+    installedFake = undefined;
+  }
+
   if (clock) {
-    clock.setSystemTime(mockingDate);
+    // Reset to the story's instant (epoch when omitted) so a reused clock is
+    // as deterministic as a freshly installed one — never inheriting the
+    // previous story's time.
+    clock.setSystemTime(now ?? 0);
   } else {
-    clock = FakeTimers.install({
-      toFake: ['Date'],
-      now: mockingDate,
-    });
+    clock = FakeTimers.install({ toFake: fake, now: now ?? 0 });
+    installedFake = nextKey;
   }
 
   // eslint-disable-next-line typescript/no-unsafe-return -- Storybook's PartialStoryFn return type is loosely typed
   return StoryFn(context);
 };
+
+const requireClock = (method: string): FakeTimers.Clock => {
+  if (!clock) {
+    throw new Error(
+      `[storybook-addon-mock-date] ${method}() was called without an installed clock. ` +
+        'Set the `mockingDate` parameter (with `now` and/or `fake`) on the story first.',
+    );
+  }
+  return clock;
+};
+
+/**
+ * Advance the mocked clock by `ms` milliseconds, running any timers
+ * (`setTimeout` / `setInterval` / `requestAnimationFrame` / …) scheduled
+ * within that window.
+ *
+ * Call this inside a story's `play` function — after the component has mounted
+ * and registered its timers — to capture a settled "after" state. Ticking from
+ * a decorator would run before mount, when no component timer exists yet.
+ *
+ * Import it from `storybook-addon-mock-date/preview` — the same entry the
+ * decorator ships from. Importing from any other path gives you a disconnected
+ * clock instance and a "called without an installed clock" error.
+ */
+export const advanceMockedTime = (ms: number): void => {
+  requireClock('advanceMockedTime').tick(ms);
+};
+
+/**
+ * Run every currently-scheduled timer until the queue drains. Use inside
+ * `play` to fast-forward to the fully settled state.
+ */
+export const runAllMockedTimers = (): void => {
+  requireClock('runAllMockedTimers').runAll();
+};
+
+/**
+ * Escape hatch: the installed `@sinonjs/fake-timers` clock (or `undefined`).
+ *
+ * Prefer `advanceMockedTime` / `runAllMockedTimers`. Mutating the returned
+ * clock directly (`uninstall` / `reset` / `setSystemTime`) bypasses the
+ * decorator's internal tracking and can leave later stories in a broken state.
+ */
+export const getMockedClock = (): FakeTimers.Clock | undefined => clock;


### PR DESCRIPTION
## Summary

Lets a story fake JS time sources **beyond `Date`** and advance the clock from `play`, so timer-driven UI (auto-dismiss toasts, debounced inputs, countdowns, count-ups, JS-driven animations) can be captured deterministically in snapshots / VRT — not just components that read `Date`.

## Motivation

`mockingDate` only faked `Date`, so any component whose visible state is driven by `setTimeout` / `setInterval` / `requestAnimationFrame` / `performance.now()` still raced the screenshot. The most common VRT flakes — a toast caught mid-dismiss, a count-up caught mid-animation — were out of reach.

## What changed

- `mockingDate` accepts an **object form `{ now, fake }`** in addition to the existing scalar. `fake` maps directly to [`@sinonjs/fake-timers`' `toFake`](https://github.com/sinonjs/fake-timers#var-clock--faketimersinstallconfig) and defaults to `['Date']`.
- New helpers exported from `storybook-addon-mock-date/preview`, for use inside `play` **after mount**:
  - `advanceMockedTime(ms)` — advance the clock, running timers scheduled within the window
  - `runAllMockedTimers()` — drain every scheduled timer
  - `getMockedClock()` — raw clock escape hatch
- The decorator reinstalls the clock only when the `toFake` set changes (`toFake` can't be mutated in place) and resets a reused clock to the story's instant (`now ?? 0`), so snapshots stay deterministic regardless of story order.
- `toDate` / `isConfig` accept `unknown` and ignore `null` / non-date input instead of crashing.
- README: new **Faking other timers** and **Advancing time in `play`** sections; corrected **What gets mocked**.
- Added a demo/test story (`auto-dismiss-toast`) and a `minor` changeset.

## Review notes

- **Backward compatibility**: the scalar `mockingDate` (a `Date`, a timestamp, or an ISO string) and the toolbar override are behaviorally unchanged and still fake only `Date`. The legacy branches in `src/with-mock-time.ts` are the thing to confirm.
- **Singleton import footgun**: the helpers close over a module-level clock, so they must be imported from `storybook-addon-mock-date/preview` (the same module the decorator ships from). Importing from elsewhere yields a disconnected instance. Documented in JSDoc + README.
- **Advancing has to happen in `play`, not a decorator** — a component registers its timers in an effect that runs after mount, so a decorator-level tick would fire before any timer exists.

## Impact

`storybook-addon-mock-date` consumers. Additive and backward compatible (`minor`).

## Testing

- `tsc --noEmit` and `vp check` (oxlint + oxfmt) pass.
- Full vitest browser suite: **8/8** — 6 existing `Date` stories + 2 new toast stories covering the freeze and advance-in-`play` paths.
