### PR TITLE
ci: make release-PR merges owner-triggered again

### DIFF
--- a/.changeset/manual-release-merge.md
+++ b/.changeset/manual-release-merge.md
@@ -1,0 +1,5 @@
+---
+'storybook-addon-mock-date': none
+---
+
+Turn off release-PR auto-merge: merging the release PR is the owner's release trigger again. Workflow-only change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,3 @@ jobs:
         with:
           build: pnpm build
           github-token: ${{ steps.app-token.outputs.token }}
-          auto-merge: true


### PR DESCRIPTION
Removes `auto-merge: true` from the `k35o/pnpm-release-action` step in `release.yml`. Auto-merging the release PR was a convenience during the batch migration, not the desired steady state — merging the release PR is the owner's release trigger again.

Includes a bump-none changeset, so merging this releases nothing.