### PR TITLE
feat: support CSF factories (CSF Next) registration

### DIFF
--- a/.changeset/csf-factories-support.md
+++ b/.changeset/csf-factories-support.md
@@ -1,0 +1,5 @@
+---
+'storybook-addon-mock-date': minor
+---
+
+Add CSF factories (CSF Next) support: the package root now exports a `definePreviewAddon` factory, so the addon can be registered with `definePreview({ addons: [mockDate()] })` and the `mockingDate` parameter and global are type-checked in `preview.meta()` / `meta.story()`. The root entry also re-exports `advanceMockedTime` / `runAllMockedTimers` / `getMockedClock`, sharing the clock with the `/preview` entry.

--- a/.storybook/local-preset.ts
+++ b/.storybook/local-preset.ts
@@ -1,9 +1,5 @@
 import { fileURLToPath } from 'node:url';
 
-export function previewAnnotations(entry = []) {
-  return [...entry, fileURLToPath(import.meta.resolve('../dist/preview.js'))];
-}
-
 export function managerEntries(entry = []) {
   return [...entry, fileURLToPath(import.meta.resolve('../dist/manager.js'))];
 }

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,9 @@
-import type { Preview } from '@storybook/react-vite';
+import { definePreview } from '@storybook/react-vite';
+import mockDate from 'storybook-addon-mock-date';
 
-const preview: Preview = {
+export default definePreview({
+  addons: [mockDate()],
   parameters: {
     mockingDate: new Date(2024, 0, 1),
   },
-};
-
-export default preview;
+});

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ const config: StorybookConfig = {
 export default config;
 ```
 
+### With CSF factories (CSF Next)
+
+If your project uses [CSF factories](https://storybook.js.org/docs/api/csf/csf-next), register the addon in `.storybook/preview.ts` as well (keep the `main.ts` entry — it provides the toolbar):
+
+```ts
+// .storybook/preview.ts
+import { definePreview } from '@storybook/your-framework';
+import mockDate from 'storybook-addon-mock-date';
+
+export default definePreview({
+  addons: [mockDate()],
+});
+```
+
+This also types the `mockingDate` parameter and global in `preview.meta()` and `meta.story()`. The `advanceMockedTime` / `runAllMockedTimers` / `getMockedClock` helpers can then be imported from the package root — it shares the clock with the `/preview` entry.
+
 ## Usage
 
 Pass a `Date`, a millisecond timestamp, or an ISO 8601 string via the `mockingDate` parameter at the story, meta, or preview level. Storybook merges parameters with the most specific value winning, so the precedence is **story > meta > preview**.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
   ],
   "type": "module",
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./preview": {
       "types": "./dist/preview.d.ts",
       "default": "./dist/preview.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,21 @@
+import { definePreviewAddon } from 'storybook/internal/csf';
+
+import preview from './preview';
+import type { MockingDateTypes } from './types';
+
+export {
+  advanceMockedTime,
+  getMockedClock,
+  runAllMockedTimers,
+} from './with-mock-time';
+export type {
+  FakeableTimer,
+  MockingDateConfig,
+  MockingDateParam,
+  MockingDateTypes,
+  MockingDateValue,
+} from './types';
+
+const mockDate = () => definePreviewAddon<MockingDateTypes>(preview);
+
+export default mockDate;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,3 +27,22 @@ export type MockingDateConfig = {
  * fakes only `Date`) or a configuration object.
  */
 export type MockingDateParam = MockingDateValue | MockingDateConfig;
+
+/**
+ * Addon type declarations for CSF factories: registering the addon via
+ * `definePreview({ addons: [mockDate()] })` types the `mockingDate`
+ * parameter and global in `preview.meta()` / `meta.story()`.
+ */
+export type MockingDateTypes = {
+  parameters: {
+    /** Freeze the clock for the story. See {@link MockingDateParam}. */
+    mockingDate?: MockingDateParam;
+  };
+  globals: {
+    /**
+     * Toolbar override: a date value that takes precedence over the
+     * `mockingDate` parameter's `now` while leaving its `fake` set intact.
+     */
+    mockingDate?: MockingDateValue;
+  };
+};

--- a/src/with-mock-time.ts
+++ b/src/with-mock-time.ts
@@ -128,9 +128,10 @@ const requireClock = (method: string): FakeTimers.Clock => {
  * and registered its timers — to capture a settled "after" state. Ticking from
  * a decorator would run before mount, when no component timer exists yet.
  *
- * Import it from `storybook-addon-mock-date/preview` — the same entry the
- * decorator ships from. Importing from any other path gives you a disconnected
- * clock instance and a "called without an installed clock" error.
+ * Import it from `storybook-addon-mock-date` or `storybook-addon-mock-date/preview`
+ * — both entries share the module-level clock the decorator uses. Importing
+ * from any other path gives you a disconnected clock instance and a "called
+ * without an installed clock" error.
  */
 export const advanceMockedTime = (ms: number): void => {
   requireClock('advanceMockedTime').tick(ms);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
     '*.{js,ts,cjs,mjs,jsx,tsx,json,jsonc}': 'vp check --fix',
   },
   pack: {
-    entry: ['src/manager.ts', 'src/preview.ts'],
+    entry: ['src/index.ts', 'src/manager.ts', 'src/preview.ts'],
     format: 'esm',
     dts: true,
     platform: 'browser',


### PR DESCRIPTION
## Summary

Adds CSF factories (CSF Next) support: the package root now exports a `definePreviewAddon`-based factory, so the addon can be registered with `definePreview({ addons: [mockDate()] })`.

## Motivation

Storybook's [CSF factories](https://storybook.js.org/docs/api/csf/csf-next) require addons to expose their preview annotations as a callable factory from the package root. Without it, factory-based projects cannot register this addon, and they miss out on typed parameters.

## Changes

- `src/index.ts`: new root entry exporting `mockDate()`, built with `definePreviewAddon<MockingDateTypes>`; it also re-exports `advanceMockedTime` / `runAllMockedTimers` / `getMockedClock`
- `MockingDateTypes` in `src/types.ts`: types the `mockingDate` parameter and global in `preview.meta()` / `meta.story()`
- `package.json`: adds the `.` export; `vite.config.ts`: adds the root build entry
- Dogfood: `.storybook/preview.ts` now registers via the factory; the local preset keeps only `managerEntries` (toolbar)
- README section for CSF factories usage + changeset (minor)

## Notes for review

- The clock-sharing invariant holds: the root and `/preview` entries share a build chunk, so both see the single module-level clock. The dogfood setup exercises exactly this — stories import `advanceMockedTime` from `/preview` while the decorator is registered via the root factory.
- Classic CSF registration via `main.ts` is unchanged (`/preview` and `/manager` stay).

## Testing

- `vp check`, `tsc --noEmit`, and `vp pack` pass
- The browser test suite (8 tests) passes with the factory registration
- Manual check in Storybook dev: the preview-level `mockingDate` set in `definePreview` renders (2024-01-01), story-level parameters override it, and the toolbar's date override still works