### PR TITLE
feat: support opt-in Temporal and Intl faking

### DIFF
--- a/.changeset/temporal-intl-opt-in.md
+++ b/.changeset/temporal-intl-opt-in.md
@@ -1,0 +1,12 @@
+---
+'storybook-addon-mock-date': minor
+---
+
+Add opt-in faking of `Temporal` and `Intl.DateTimeFormat`, and accept Temporal values as the mocked instant.
+
+- `fake: ['Date', 'Temporal']` freezes the `Temporal.Now` namespace in browsers with native `Temporal` (Chrome/Edge 144+, Firefox 139+, Node.js 26+); `fake: ['Date', 'Intl']` routes zero-argument `Intl.DateTimeFormat#format` / `#formatToParts` — which read the system clock directly rather than going through `Date.now` — through the mocked clock.
+- Requested APIs that don't exist in the environment (e.g. no native `Temporal` in Safari yet) are now skipped instead of throwing, so a story can list `'Temporal'` without breaking on browsers that lack it.
+- `mockingDate` (and the object form's `now`) now also accepts a `Temporal.Instant` / `Temporal.ZonedDateTime` — any object carrying `epochMilliseconds`, exported as the `TemporalInstantLike` type.
+- The redundant `@types/sinonjs__fake-timers` devDependency is gone; `@sinonjs/fake-timers` ships its own types, including `'Temporal'` and `'Intl'` in `FakeMethod`.
+
+The default `fake` set is unchanged (`['Date']`) — fully backwards compatible.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Storybook Addon Mocking Date
 
-A [Storybook](https://storybook.js.org/) addon that mocks the JavaScript `Date` for individual stories using [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers). Useful for components that read the current date or time and need deterministic snapshots, visual regression tests, or coverage of time-sensitive UI such as relative timestamps and seasonal greetings.
+A [Storybook](https://storybook.js.org/) addon that mocks the JavaScript `Date` — and, opt-in, `Temporal` and `Intl.DateTimeFormat` — for individual stories using [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers). Useful for components that read the current date or time and need deterministic snapshots, visual regression tests, or coverage of time-sensitive UI such as relative timestamps and seasonal greetings.
 
 ## Requirements
 
@@ -51,7 +51,7 @@ This also types the `mockingDate` parameter and global in `preview.meta()` and `
 
 ## Usage
 
-Pass a `Date`, a millisecond timestamp, or an ISO 8601 string via the `mockingDate` parameter at the story, meta, or preview level. Storybook merges parameters with the most specific value winning, so the precedence is **story > meta > preview**.
+Pass a `Date`, a millisecond timestamp, an ISO 8601 string, or a `Temporal.Instant` / `Temporal.ZonedDateTime` via the `mockingDate` parameter at the story, meta, or preview level. Storybook merges parameters with the most specific value winning, so the precedence is **story > meta > preview**.
 
 ```ts
 // Button.stories.ts
@@ -100,7 +100,7 @@ A story whose merged `mockingDate` is `undefined` reverts the system clock to th
 
 ### Faking other timers
 
-By default only `Date` is mocked. To freeze other JavaScript time sources too, pass the **object form** of `mockingDate` with a `fake` array — its values map directly to [`@sinonjs/fake-timers`' `toFake`](https://github.com/sinonjs/fake-timers#var-clock--faketimersinstallconfig) (e.g. `'setTimeout'`, `'setInterval'`, `'requestAnimationFrame'`, `'performance'`):
+By default only `Date` is mocked. To freeze other time sources too — `Temporal`, `Intl`, or scheduling APIs like `setTimeout` / `setInterval` / `requestAnimationFrame` / `performance` — pass the **object form** of `mockingDate` with a `fake` array — its values map directly to [`@sinonjs/fake-timers`' `toFake`](https://github.com/sinonjs/fake-timers#var-clock--faketimersinstallconfig):
 
 ```ts
 export const Toast: Story = {
@@ -114,7 +114,21 @@ export const Toast: Story = {
 };
 ```
 
-The scalar form (`mockingDate: new Date(...)`, a timestamp, or an ISO string) is unchanged and still fakes only `Date`, so existing stories keep working as-is. When `fake` is omitted it defaults to `['Date']`.
+An explicit `fake` array **replaces** the default entirely — `fake: ['setTimeout']` fakes only `setTimeout` and leaves `Date` real. When `fake` is omitted (including the scalar form) it defaults to `['Date']`, so existing stories keep working as-is.
+
+Components that read the clock through `Temporal.Now` or a zero-argument `Intl.DateTimeFormat#format` need those APIs faked too — faking `Date` alone leaves them on the real clock:
+
+```ts
+export const ChristmasBanner: Story = {
+  parameters: {
+    mockingDate: {
+      now: '2024-12-25T12:00:00Z',
+      // freeze Temporal.Now and zero-arg Intl.DateTimeFormat#format as well
+      fake: ['Date', 'Temporal', 'Intl'],
+    },
+  },
+};
+```
 
 > **rAF needs `performance`.** Animation libraries (framer-motion, react-spring, GSAP, Lottie, three.js) compute their delta from `performance.now()`, so fake `requestAnimationFrame` **and** `performance` together — faking rAF alone leaves the solver with a zero/NaN delta.
 
@@ -183,13 +197,22 @@ The decorator runs the same way; only the toolbar manager bundle is skipped.
 
 ### What gets mocked
 
-By default only the `Date` constructor and its static methods (`Date.now`, `Date.parse`, etc.) are replaced; `setTimeout`, `setInterval`, `requestAnimationFrame`, and the rest of the timer APIs keep using the host clock. Opt into faking any of them per story with the `fake` option (see [Faking other timers](#faking-other-timers)).
+By default only the `Date` constructor and its static methods (`Date.now`, `Date.parse`, etc.) are replaced; everything else keeps using the host clock. Opt into more per story with the `fake` option (see [Faking other timers](#faking-other-timers)):
 
-Note that `@sinonjs/fake-timers` only controls JavaScript timers and the clock. CSS animations/transitions, the Web Animations API, `IntersectionObserver`/`ResizeObserver`, and network requests are unaffected — disable or mock those separately for stable visual snapshots.
+- **`'Temporal'`** — replaces the `Temporal.Now` namespace (`instant()`, `zonedDateTimeISO()`, `plainDateISO()`, …), in browsers that ship [native `Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal#browser_compatibility) (Chrome/Edge 144+, Firefox 139+, Node.js 26+). Where `Temporal` doesn't exist yet the entry is skipped harmlessly. Imported polyfills (`temporal-polyfill`, `@js-temporal/polyfill`) bypass the global and are not replaced, but they derive the current time from `Date.now()` internally, so the `Date` fake pins them at millisecond precision.
+- **`'Intl'`** — routes zero-argument `Intl.DateTimeFormat` `format()` / `formatToParts()` calls, which read the system clock directly rather than going through `Date.now`, through the mocked clock. Calls with an explicit date argument behave as usual (except a falsy `0`, which upstream `@sinonjs/fake-timers` treats as absent and formats as the mocked instant).
+- **Scheduling APIs** (`'setTimeout'`, `'setInterval'`, `'requestAnimationFrame'`, `'performance'`, and the rest) — freezes timers so timer-driven UI can be advanced deterministically from `play`.
+
+### What stays real
+
+- **The timezone.** The addon freezes the _instant_, not the environment: `Date.prototype.getTimezoneOffset()`, `Intl.DateTimeFormat().resolvedOptions().timeZone`, and `Temporal.Now.timeZoneId()` all keep reporting the host's timezone. To render a story as if in another timezone, launch the browser with one — e.g. Playwright's `timezoneId` option or the `TZ` environment variable.
+- **Values captured before the decorator runs.** A module-scope `const now = new Date()` is evaluated at import time, before any story's mock is installed.
+- **Other realms.** Web Workers, Service Workers, and other iframes have their own globals; the mock is installed only in the preview iframe.
+- **Everything outside the JS clock.** CSS animations/transitions, the Web Animations API, `IntersectionObserver`/`ResizeObserver`, `AbortSignal.timeout()`, and network requests are unaffected — disable or mock those separately for stable visual snapshots.
 
 ### Multiple stories in a docs page
 
-Stories rendered together on the same docs page (e.g. autodocs pages, MDX pages with several `<Canvas>` blocks) share one `globalThis.Date`, because the underlying `@sinonjs/fake-timers` installs the mock globally. Each story's `mockingDate` is applied correctly during its initial render — so static snapshots show the expected date for every story — but any code that reads `Date` _after_ that render sees whichever story's mock was installed last. Live-updating UI such as countdowns, "time ago" labels that refresh, or running clocks will therefore all converge on a single value across the page.
+Stories rendered together on the same docs page (e.g. autodocs pages, MDX pages with several `<Canvas>` blocks) share one set of mocked globals (`Date`, `Temporal`, `Intl`), because the underlying `@sinonjs/fake-timers` installs the mock globally. Each story's `mockingDate` is applied correctly during its initial render — so static snapshots show the expected date for every story — but any code that reads the clock _after_ that render sees whichever story's mock was installed last. Live-updating UI such as countdowns, "time ago" labels that refresh, or running clocks will therefore all converge on a single value across the page.
 
 If you need each story on a docs page to keep its own `mockingDate` for ongoing `new Date()` reads, render the stories in separate iframes by setting `parameters.docs.story.inline` to `false`:
 
@@ -204,4 +227,4 @@ const preview: Preview = {
 };
 ```
 
-Each iframe gets its own `globalThis.Date`, so the mocks no longer leak between stories. The tradeoff is the extra iframe startup cost per story on the page.
+Each iframe gets its own globals, so the mocks no longer leak between stories. The tradeoff is the extra iframe startup cost per story on the page.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@types/node": "24.13.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
-    "@types/sinonjs__fake-timers": "15.0.1",
     "@vitejs/plugin-react": "6.0.5",
     "@vitest/browser-playwright": "4.1.10",
     "npm-run-all2": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storybook-addon-mock-date",
   "version": "3.1.1",
-  "description": "Storybook addon that mocks the JavaScript Date for individual stories.",
+  "description": "Storybook addon that mocks the JavaScript Date — and opt-in Temporal and Intl.DateTimeFormat — for individual stories.",
   "keywords": [
     "storybook-addon",
     "data-state",
@@ -9,6 +9,7 @@
     "mocking",
     "date",
     "time",
+    "temporal",
     "fake-timers"
   ],
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@types/react-dom':
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
-      '@types/sinonjs__fake-timers':
-        specifier: 15.0.1
-        version: 15.0.1
       '@vitejs/plugin-react':
         specifier: 6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1))
@@ -1191,9 +1188,6 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
-
-  '@types/sinonjs__fake-timers@15.0.1':
-    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -3227,8 +3221,6 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
-
-  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type {
   MockingDateParam,
   MockingDateTypes,
   MockingDateValue,
+  TemporalInstantLike,
 } from './types';
 
 const mockDate = () => definePreviewAddon<MockingDateTypes>(preview);

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -22,4 +22,5 @@ export type {
   MockingDateConfig,
   MockingDateParam,
   MockingDateValue,
+  TemporalInstantLike,
 } from './types';

--- a/src/stories/current-date.stories.tsx
+++ b/src/stories/current-date.stories.tsx
@@ -35,6 +35,19 @@ export const StringMockingDate: Story = {
   },
 };
 
+// A `Temporal.Instant` / `Temporal.ZonedDateTime` (anything carrying
+// `epochMilliseconds`) also works as the bare parameter. Midday UTC keeps the
+// local calendar date identical across the timezones CI and dev machines run
+// in.
+export const TemporalInstantMockingDate: Story = {
+  parameters: {
+    mockingDate: { epochMilliseconds: Date.UTC(2025, 2, 3, 12) },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('time')).toHaveTextContent('2025年3月3日');
+  },
+};
+
 export const GlobalOverridesParameter: Story = {
   parameters: {
     mockingDate: new Date(2023, 6, 1),

--- a/src/stories/current-intl-date.stories.tsx
+++ b/src/stories/current-intl-date.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import { CurrentIntlDate } from './current-intl-date';
+
+const meta = {
+  component: CurrentIntlDate,
+} satisfies Meta<typeof CurrentIntlDate>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Adding 'Intl' to `fake` routes zero-arg `Intl.DateTimeFormat#format`
+// through the mocked clock; without it the call reads the real system time
+// even while `Date` is faked.
+export const FakedIntlFormat: Story = {
+  parameters: {
+    mockingDate: {
+      now: '2024-07-01T12:00:00Z',
+      fake: ['Date', 'Intl'],
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('time')).toHaveTextContent('2024年7月1日');
+  },
+};

--- a/src/stories/current-intl-date.tsx
+++ b/src/stories/current-intl-date.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import type { FC } from 'react';
+
+export const CurrentIntlDate: FC = () => {
+  // Zero-arg `format()` reads the system clock directly (not through
+  // `Date.now`), which is exactly the leak the default `Intl` fake plugs.
+  // UTC output keeps assertions timezone-independent.
+  const formatter = new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  });
+  return <time>{formatter.format()}</time>;
+};

--- a/src/stories/current-temporal-date.stories.tsx
+++ b/src/stories/current-temporal-date.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
+
+import { CurrentTemporalDate } from './current-temporal-date';
+
+const meta = {
+  component: CurrentTemporalDate,
+} satisfies Meta<typeof CurrentTemporalDate>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Adding 'Temporal' to `fake` freezes `Temporal.Now` alongside `Date`.
+// Midday UTC keeps the derived calendar date identical across the timezones
+// CI and dev machines run in.
+export const FakedTemporalNow: Story = {
+  parameters: {
+    mockingDate: {
+      now: '2024-01-01T12:00:00Z',
+      fake: ['Date', 'Temporal'],
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('time')).toHaveTextContent('2024-01-01');
+  },
+};
+
+// A `Temporal.Instant`-like value (anything carrying `epochMilliseconds`)
+// works as `now`.
+export const TemporalInstantNow: Story = {
+  parameters: {
+    mockingDate: {
+      now: { epochMilliseconds: Date.UTC(2024, 6, 1, 12) },
+      fake: ['Date', 'Temporal'],
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole('time')).toHaveTextContent('2024-07-01');
+  },
+};

--- a/src/stories/current-temporal-date.tsx
+++ b/src/stories/current-temporal-date.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import type { FC } from 'react';
+
+// TypeScript ships no Temporal lib types yet, so reach the global
+// structurally instead of relying on lib declarations.
+type TemporalGlobal = {
+  Now: { plainDateISO: () => { toString: () => string } };
+};
+
+export const CurrentTemporalDate: FC = () => {
+  const temporal = (globalThis as { Temporal?: TemporalGlobal }).Temporal;
+  if (!temporal) {
+    return <p>Temporal is not available in this browser.</p>;
+  }
+  return <time>{temporal.Now.plainDateISO().toString()}</time>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,15 @@
 import type { FakeMethod } from '@sinonjs/fake-timers';
 
+/**
+ * Structural stand-in for `Temporal.Instant` / `Temporal.ZonedDateTime` —
+ * anything carrying an `epochMilliseconds` number — so accepting Temporal
+ * values does not require Temporal lib types (TypeScript does not ship them
+ * yet).
+ */
+export type TemporalInstantLike = { epochMilliseconds: number };
+
 /** A point in time accepted by the `mockingDate` parameter. */
-export type MockingDateValue = Date | number | string;
+export type MockingDateValue = Date | number | string | TemporalInstantLike;
 
 /**
  * Timer / clock APIs that can be faked. Forwarded verbatim to
@@ -15,16 +23,18 @@ export type MockingDateConfig = {
   /** The instant to freeze the clock at. Defaults to the epoch (`0`). */
   now?: MockingDateValue;
   /**
-   * Which timer / clock APIs to fake. Defaults to `['Date']`, matching the
-   * historical behaviour. Expand it to also intercept `setTimeout`,
-   * `setInterval`, `requestAnimationFrame`, `performance`, etc.
+   * Which timer / clock APIs to fake. Defaults to `['Date']`. Add
+   * `'Temporal'` / `'Intl'` to freeze those clock readers too, or timer APIs
+   * (`setTimeout`, `setInterval`, `requestAnimationFrame`, `performance`,
+   * etc.) to intercept scheduling. An explicit array replaces the default
+   * entirely.
    */
   fake?: FakeableTimer[];
 };
 
 /**
- * The `mockingDate` parameter accepts either a bare date value (legacy form,
- * fakes only `Date`) or a configuration object.
+ * The `mockingDate` parameter accepts either a bare date value (shorthand for
+ * `{ now }` with the default `fake` set) or a configuration object.
  */
 export type MockingDateParam = MockingDateValue | MockingDateConfig;
 

--- a/src/with-mock-time.ts
+++ b/src/with-mock-time.ts
@@ -7,12 +7,19 @@ import type {
   MockingDateConfig,
   MockingDateParam,
   MockingDateValue,
+  TemporalInstantLike,
 } from './types';
 
 let clock: FakeTimers.Clock | undefined;
 let installedFake: string | undefined;
 
 const DEFAULT_FAKE: FakeableTimer[] = ['Date'];
+
+const isInstantLike = (value: unknown): value is TemporalInstantLike =>
+  typeof value === 'object' &&
+  value !== null &&
+  'epochMilliseconds' in value &&
+  typeof value.epochMilliseconds === 'number';
 
 // Accepts `unknown` because Storybook parameters/globals are untyped at
 // runtime — this gracefully ignores `null` and any non-date junk instead of
@@ -28,11 +35,20 @@ const toDate = (value: unknown): Date | number | undefined => {
   if (typeof value === 'number' || value instanceof Date) {
     return value;
   }
+  if (isInstantLike(value)) {
+    return value.epochMilliseconds;
+  }
   return undefined;
 };
 
+// `now`/`fake` keys win over instant-likeness so that a (nonsensical) object
+// carrying both `epochMilliseconds` and config keys keeps its `fake` set
+// instead of silently dropping it. Real Temporal objects carry neither key.
 const isConfig = (value: unknown): value is MockingDateConfig =>
-  typeof value === 'object' && value !== null && !(value instanceof Date);
+  typeof value === 'object' &&
+  value !== null &&
+  !(value instanceof Date) &&
+  ('now' in value || 'fake' in value || !isInstantLike(value));
 
 type NormalizedMockingDate = {
   now: Date | number | undefined;
@@ -58,10 +74,12 @@ export const normalizeMockingDate = (
   return { now, fake };
 };
 
-const isDefaultFake = (fake: FakeableTimer[]): boolean =>
-  fake.length === 1 && fake[0] === 'Date';
-
 const fakeKeyOf = (fake: FakeableTimer[]): string => fake.toSorted().join(',');
+
+const DEFAULT_FAKE_KEY = fakeKeyOf(DEFAULT_FAKE);
+
+const isDefaultFake = (fake: FakeableTimer[]): boolean =>
+  fakeKeyOf(fake) === DEFAULT_FAKE_KEY;
 
 export const withMockTime = (
   StoryFn: PartialStoryFn,
@@ -72,8 +90,8 @@ export const withMockTime = (
     context.globals[GLOBAL_KEY] as MockingDateValue | undefined,
   );
 
-  // Preserve the original behaviour: with no date and only the default
-  // `['Date']` fake set there is nothing to mock.
+  // With no date and only the default `['Date']` fake set there is nothing
+  // to mock.
   const shouldMock = now !== undefined || !isDefaultFake(fake);
 
   if (!shouldMock) {
@@ -101,7 +119,14 @@ export const withMockTime = (
     // previous story's time.
     clock.setSystemTime(now ?? 0);
   } else {
-    clock = FakeTimers.install({ toFake: fake, now: now ?? 0 });
+    // `ignoreMissingTimers` keeps stories alive in environments that lack one
+    // of the requested APIs (e.g. no native `Temporal` in Safari yet) —
+    // fake-timers throws on absent globals otherwise.
+    clock = FakeTimers.install({
+      toFake: fake,
+      now: now ?? 0,
+      ignoreMissingTimers: true,
+    });
     installedFake = nextKey;
   }
 


### PR DESCRIPTION
## What

- `fake: ['Date', 'Temporal']` freezes the `Temporal.Now` namespace in browsers with native `Temporal` (Chrome/Edge 144+, Firefox 139+, Node.js 26+), and `fake: ['Date', 'Intl']` routes zero-argument `Intl.DateTimeFormat#format` / `#formatToParts` through the mocked clock. Both map straight to `@sinonjs/fake-timers` 15.4's `toFake`.
- The decorator now passes `ignoreMissingTimers: true`, so a story listing `'Temporal'` keeps rendering in browsers without the native global (e.g. Safari) instead of crashing with a `ReferenceError`.
- `mockingDate` (and the object form's `now`) accepts `Temporal.Instant` / `Temporal.ZonedDateTime` — typed structurally as `TemporalInstantLike` (`{ epochMilliseconds }`) since TypeScript ships no Temporal lib types yet.
- Dropped the redundant `@types/sinonjs__fake-timers` devDependency: the package ships its own types, which module resolution already prefers, and the DT package's `FakeMethod` union is outdated (no `'Temporal'` / `'Intl'`).
- Dogfood stories cover the three new paths with play assertions; README documents the opt-ins plus a new "What stays real" section (timezone, values captured at import time, other realms, non-JS clocks).

## Why

Components that read the clock through `Temporal.Now` or zero-arg `Intl.DateTimeFormat#format` leak the real time even while `Date` is faked — those APIs read the system clock directly rather than going through `Date.now`, so "time-frozen" stories were only frozen for `Date` readers.

## Notes for review

- The default `fake` set is unchanged (`['Date']`), so this is fully backwards compatible and ships as a **minor** (changeset included). Flipping the default to `['Date', 'Temporal', 'Intl']` is deliberately deferred to the next major — proposed in #119.
- An object carrying `now`/`fake` keys is treated as the config form even if it also has `epochMilliseconds`, so a malformed mix doesn't silently drop its `fake` set.
- Mocked instants in the new stories sit at midday UTC (and the Intl formatter pins `timeZone: 'UTC'`) so derived calendar dates match on UTC CI and JST dev machines.
- Story tests run on Playwright's pinned Chromium, which ships native `Temporal`; the no-`Temporal` fallback path is intentionally not play-asserted to avoid a conditional (and thus false-negative-prone) test.