### PR TITLE
fix: drop runtime storybook/internal/csf import from the factory entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { definePreviewAddon } from 'storybook/internal/csf';
+import type { PreviewAddon } from 'storybook/internal/csf';
 
 import preview from './preview';
 import type { MockingDateTypes } from './types';
@@ -17,6 +17,12 @@ export type {
   TemporalInstantLike,
 } from './types';
 
-const mockDate = () => definePreviewAddon<MockingDateTypes>(preview);
+// `definePreviewAddon` is an identity function at runtime, but calling it makes
+// this entry depend on `storybook/internal/csf` at runtime. When a consumer
+// registers the factory in `preview.ts`, Vite's dependency optimizer prebundles
+// a copy of those internals into the addon chunk, which makes stories time out
+// randomly under Storybook's vitest browser mode. Borrow the type only and
+// return the `/preview` annotations as-is.
+const mockDate = (): PreviewAddon<MockingDateTypes> => preview;
 
 export default mockDate;


### PR DESCRIPTION
The factory entry called `definePreviewAddon`, which is an identity function at runtime but makes the root entry depend on `storybook/internal/csf`. When a consumer registers the factory in `preview.ts`, Vite's dependency optimizer prebundles a copy of those internals into the addon chunk. In `storybook-addon-determinism`, which shares this exact entry structure, that combination made consumer stories time out randomly under Storybook's vitest browser mode (34–65 failures per run in a 547-test suite; zero across 6 consecutive runs after the fix). This applies the same fix here preventively.

The factory now borrows `PreviewAddon` as a type-only import and returns the `/preview` annotations as-is, so the published root entry has no runtime `storybook/internal` import and stays runtime-equivalent to composing `/preview` directly. No API change.